### PR TITLE
adding xacc-benchmark plugins

### DIFF
--- a/benchmark/moleculegenerator.py
+++ b/benchmark/moleculegenerator.py
@@ -1,0 +1,9 @@
+#!usr/bin/python3
+
+from abc import abstractmethod, ABC
+
+class MoleculeGenerator(ABC):
+
+    @abstractmethod
+    def generate(self, molecule):
+        pass

--- a/benchmark/psi4openfermion.py
+++ b/benchmark/psi4openfermion.py
@@ -1,0 +1,35 @@
+#!usr/bin/python3
+
+from pelix.ipopo.decorators import ComponentFactory, Property, Requires, Provides, \
+    Validate, Invalidate, Instantiate
+from openfermion.hamiltonians import MolecularData
+from openfermionpsi4 import run_psi4
+from openfermion.transforms import get_fermion_operator
+from moleculegenerator import MoleculeGenerator
+import ast
+@ComponentFactory("Psi4OF_molecule_generator_factory")
+@Provides("molecule_generator_service")
+@Property("_molecule_generator","molecule_generator", "psi4Of")
+@Property("_name", "name", "psi4Of")
+@Instantiate("Psi4OF_molecule_generator_instance")
+class Psi4OpenFermion(MoleculeGenerator):
+
+    def __init__(self):
+        print("MoleculeGenerator initialized")
+
+    @Validate
+    def validate(self, context):
+        print("MoleculeGenerator validated")
+
+    @Invalidate
+    def invalidate(self, context):
+        print("MoleculeGenerator invalidated")
+
+    def generate(self, inputParams):
+        mdata = MolecularData(ast.literal_eval(inputParams['geometry']),
+                              inputParams['basis'],
+                              int(inputParams['multiplicity']),
+                              int(inputParams['charge']))
+        molecule = run_psi4(mdata, run_scf=1, run_fci=1)
+        fermiOp = get_fermion_operator(molecule.get_molecular_hamiltonian())
+        return fermiOp

--- a/benchmark/vqe.py
+++ b/benchmark/vqe.py
@@ -1,0 +1,58 @@
+#!usr/bin/python3
+
+from pelix.ipopo.decorators import ComponentFactory, Property, Requires, BindField, UnbindField, Provides, \
+    Validate, Invalidate, Instantiate
+
+import ast, configparser, xacc, xaccvqe
+from algorithm import Algorithm
+
+@ComponentFactory("vqe_algorithm_factory")
+@Provides("xacc_algorithm_service")
+@Property("_algorithm","algorithm","vqe")
+@Property("_name", "name", "vqe")
+@Requires("_molecule_generator", "molecule_generator_service", aggregate=True)
+@Instantiate("vqe_algorithm_instance")
+class VQE(Algorithm):
+
+    def __init__(self):
+        self.molecule_generators = {}
+        print("VQE Algorithm...")
+
+    @Validate
+    def validate(self, context):
+        print("VQE Algorithm Validated")
+
+    @BindField('_molecule_generator')
+    def bind_dict(self, field, service, svc_ref):
+        print('binding molecule gen')
+        generator = svc_ref.get_property('molecule_generator')
+        self.molecule_generators[generator] = service
+
+    @UnbindField('_molecule_generator')
+    def unbind_dict(self, field, service, svc_ref):
+
+        generator = svc_ref.get_property('molecule_generator')
+
+        del self.molecule_generators[generator]
+
+
+    @Invalidate
+    def invalidate(self, context):
+        print("VQE Algorithm Stopped")
+
+    def execute(self, inputParams):
+        print("VQE Algorithm Executing")
+        qpu = xacc.getAccelerator(inputParams['accelerator'])
+        ir_generator = xacc.getIRGenerator(inputParams['ansatz'])
+        n_electrons = int(inputParams['n-electrons'])
+        xaccOp = xaccvqe.compile(
+            self.molecule_generators[inputParams['molecule-generator']].generate(settings))
+        n_qubits = xaccOp.nQubits()
+        buffer = qpu.createBuffer(inputParams['qubit-register'], n_qubits)
+        function = ir_generator.generate([n_electrons, n_qubits])
+        results = xaccvqe.execute(xaccOp, buffer, **{'task': 'vqe',
+                                         'n-electrons': n_electrons})
+        return buffer
+
+    def analyze(self, buffer, inputParams):
+        print(buffer.getInformation())

--- a/benchmark/vqe.py
+++ b/benchmark/vqe.py
@@ -46,7 +46,7 @@ class VQE(Algorithm):
         ir_generator = xacc.getIRGenerator(inputParams['ansatz'])
         n_electrons = int(inputParams['n-electrons'])
         xaccOp = xaccvqe.compile(
-            self.molecule_generators[inputParams['molecule-generator']].generate(settings))
+            self.molecule_generators[inputParams['molecule-generator']].generate(inputParams))
         n_qubits = xaccOp.nQubits()
         buffer = qpu.createBuffer(inputParams['qubit-register'], n_qubits)
         function = ir_generator.generate([n_electrons, n_qubits])

--- a/benchmark/vqe_energy.py
+++ b/benchmark/vqe_energy.py
@@ -1,0 +1,62 @@
+#!usr/bin/python3
+
+from pelix.ipopo.decorators import ComponentFactory, Property, Requires, BindField, UnbindField, Provides, \
+    Validate, Invalidate, Instantiate
+
+import ast, configparser, xacc, xaccvqe
+from algorithm import Algorithm
+
+@ComponentFactory("VQE_energy_algorithm_factory")
+@Provides("xacc_algorithm_service")
+@Property("_algorithm","algorithm","vqe-energy")
+@Property("_name", "name", "vqe-energy")
+@Requires("_molecule_generator", "molecule_generator_service", aggregate=True)
+@Instantiate("VQE_energy_algorithm_instance")
+class VQEEnergy(Algorithm):
+
+    def __init__(self):
+        self.molecule_generators = {}
+        print("VQEEnergy Algorithm...")
+
+
+    @Validate
+    def validate(self, context):
+        print("VQEEnergy Algorithm Validated")
+
+
+    @BindField('_molecule_generator')
+    def bind_dict(self, field, service, svc_ref):
+
+        generator = svc_ref.get_property('molecule_generator')
+        self.molecule_generators[generator] = service
+
+
+    @UnbindField('_molecule_generator')
+    def unbind_dict(self, field, service, svc_ref):
+
+        generator = svc_ref.get_property('molecule_generator')
+
+        del self.molecule_generators[generator]
+
+
+    @Invalidate
+    def invalidate(self, context):
+        print("VQEEnergy Algorithm Stopped")
+
+
+    def execute(self, inputParams):
+        print("VQEEnergy Algorithm Executing")
+        qpu = xacc.getAccelerator(inputParams['accelerator'])
+        ir_generator = xacc.getIRGenerator(inputParams['ansatz'])
+        n_electrons = int(inputParams['n-electrons'])
+        xaccOp = xaccvqe.compile(
+            self.molecule_generators[inputParams['molecule-generator']].generate(inputParams))
+        n_qubits = xaccOp.nQubits()
+        buffer = qpu.createBuffer(inputParams['qubit-register'], n_qubits)
+        function = ir_generator.generate([n_electrons, n_qubits])
+        results = xaccvqe.execute(xaccOp, buffer, **{'task': 'compute-energy',
+                                         'n-electrons': n_electrons, 'vqe-params': inputParams['vqe-params']})
+        return buffer
+
+    def analyze(self, buffer, inputParams):
+        print(buffer.getInformation())


### PR DESCRIPTION
/benchmarks/ contains the Python plugins for the XACC Benchmark Framework
Signed-off-by: Zachary Parks <1zp@ornl.gov>