### PR TITLE
More consistent naming between iPOPO components, services, and instances

### DIFF
--- a/benchmark/vqe.py
+++ b/benchmark/vqe.py
@@ -2,21 +2,17 @@ from pelix.ipopo.decorators import (ComponentFactory, Property, Requires,
                                     BindField, UnbindField, Provides, Validate,
                                     Invalidate, Instantiate)
 import ast
-import configparser
 import xacc
 import xaccvqe
-import time
-import os
 from xacc import BenchmarkAlgorithm
 from vqe_base import VQEBase
 
-@ComponentFactory("vqe_algorithm_factory")
-@Provides("benchmark_algorithm_service")
-@Property("_algorithm", "algorithm", "vqe")
+@ComponentFactory("vqe_benchmark_factory")
+@Provides("benchmark_algorithm")
 @Property("_name", "name", "vqe")
-@Requires("_ansatz_generator", "ansatz_generator_service", aggregate=True)
-@Requires("_hamiltonian_generator", "hamiltonian_generator_service", aggregate=True)
-@Instantiate("vqe_algorithm_instance")
+@Requires("_ansatz_generators", "ansatz_generator", aggregate=True)
+@Requires("_hamiltonian_generators", "hamiltonian_generator", aggregate=True)
+@Instantiate("vqe_benchmark")
 class VQE(VQEBase):
     """
         Algorithm class inherited from VQEBase to execute the VQE algorithm
@@ -24,16 +20,16 @@ class VQE(VQEBase):
     def __init__(self):
         super().__init__()
 
-    @BindField('_ansatz_generator')
-    @BindField('_hamiltonian_generator')
+    @BindField('_ansatz_generators')
+    @BindField('_hamiltonian_generators')
     def bind_dicts(self, field, service, svc_ref):
         """
             iPOPO method to bind ansatz and hamiltonian generator dependencies for use by the Algorithm bundle
         """
         super().bind_dicts(field, service, svc_ref)
 
-    @UnbindField('_ansatz_generator')
-    @UnbindField('_hamiltonian_generator')
+    @UnbindField('_ansatz_generators')
+    @UnbindField('_hamiltonian_generators')
     def unbind_dicts(self, field, service, svc_ref):
         """
             iPOPO method to unbind ansatz and hamiltonian generator dependencies for use by the Algorithm bundle

--- a/benchmark/vqe_energy.py
+++ b/benchmark/vqe_energy.py
@@ -11,13 +11,12 @@ import os
 from xacc import BenchmarkAlgorithm
 from vqe_base import VQEBase
 
-@ComponentFactory("VQE_energy_algorithm_factory")
-@Provides("benchmark_algorithm_service")
-@Property("_algorithm", "algorithm", "vqe-energy")
+@ComponentFactory("vqe-energy_benchmark_factory")
+@Provides("benchmark_algorithm")
 @Property("_name", "name", "vqe-energy")
-@Requires("_hamiltonian_generator", "hamiltonian_generator_service", aggregate=True)
-@Requires("_ansatz_generator", "ansatz_generator_service", aggregate=True)
-@Instantiate("VQE_energy_algorithm_instance")
+@Requires("_hamiltonian_generators", "hamiltonian_generator", aggregate=True)
+@Requires("_ansatz_generators", "ansatz_generator", aggregate=True)
+@Instantiate("vqe-energy_benchmark")
 class VQEEnergy(VQEBase):
     """
         Algorithm class inherited from VQEBase to execute the 'compute-energy' task of VQE
@@ -25,16 +24,16 @@ class VQEEnergy(VQEBase):
     def __init__(self):
         super().__init__()
 
-    @BindField('_ansatz_generator')
-    @BindField('_hamiltonian_generator')
+    @BindField('_ansatz_generators')
+    @BindField('_hamiltonian_generators')
     def bind_dicts(self, field, service, svc_ref):
         """
             iPOPO method to bind ansatz and hamiltonian generator dependencies for use by the Algorithm bundle
         """
         super().bind_dicts(field, service, svc_ref)
 
-    @UnbindField('_ansatz_generator')
-    @UnbindField('_hamiltonian_generator')
+    @UnbindField('_ansatz_generators')
+    @UnbindField('_hamiltonian_generators')
     def unbind_dicts(self, field, service, svc_ref):
         """
             iPOPO method to unbind ansatz and hamiltonian generator dependencies for use by the Algorithm bundle

--- a/benchmark/vqe_param_sweep.py
+++ b/benchmark/vqe_param_sweep.py
@@ -1,7 +1,6 @@
 from pelix.ipopo.decorators import (ComponentFactory, Property, Requires,
                                     BindField, UnbindField, Provides, Validate,
                                     Invalidate, Instantiate)
-
 import ast
 import configparser
 import xacc
@@ -10,15 +9,13 @@ import time
 import os
 from xacc import BenchmarkAlgorithm
 from vqe_base import VQEBase
-from _pyxaccvqe import *
 
-@ComponentFactory("VQE_param_sweep_algorithm_factory")
-@Provides("benchmark_algorithm_service")
-@Property("_algorithm", "algorithm", "param-sweep")
+@ComponentFactory("param-sweep_benchmark_factory")
+@Provides("benchmark_algorithm")
 @Property("_name", "name", "param-sweep")
-@Requires("_hamiltonian_generator", "hamiltonian_generator_service", aggregate=True)
-@Requires("_ansatz_generator", "ansatz_generator_service", aggregate=True)
-@Instantiate("VQE_param_sweep_algorithm_instance")
+@Requires("_hamiltonian_generators", "hamiltonian_generator", aggregate=True)
+@Requires("_ansatz_generators", "ansatz_generator", aggregate=True)
+@Instantiate("param-sweep_benchmark")
 class ParamSweep(VQEBase):
     """
         Algorithm class inherited from VQEBase to execute the 'compute-energy' task of VQE
@@ -26,16 +23,16 @@ class ParamSweep(VQEBase):
     def __init__(self):
         super().__init__()
 
-    @BindField('_ansatz_generator')
-    @BindField('_hamiltonian_generator')
+    @BindField('_ansatz_generators')
+    @BindField('_hamiltonian_generators')
     def bind_dicts(self, field, service, svc_ref):
         """
             iPOPO method to bind ansatz and hamiltonian generator dependencies for use by the Algorithm bundle
         """
         super().bind_dicts(field, service, svc_ref)
 
-    @UnbindField('_ansatz_generator')
-    @UnbindField('_hamiltonian_generator')
+    @UnbindField('_ansatz_generators')
+    @UnbindField('_hamiltonian_generators')
     def unbind_dicts(self, field, service, svc_ref):
         """
             iPOPO method to unbind ansatz and hamiltonian generator dependencies for use by the Algorithm bundle
@@ -78,7 +75,7 @@ class ParamSweep(VQEBase):
 
         for param in self.linspace(low_bound, up_bound, num_params):
             self.vqe_options_dict['vqe-params'] = str(param)
-            results = execute(self.op, self.buffer, **self.vqe_options_dict)
+            results = xaccvqe.execute(self.op, self.buffer, **self.vqe_options_dict)
         return self.buffer
 
     def analyze(self, buffer, inputParams):


### PR DESCRIPTION
Changes to iPOPO naming:

removed "_service" from service specifications ("benchmark_algorithm")
remove "_instance" from instance names ("vqe_benchmark")
Keep names consistent across specifications, instances, and component names ("vqe_benchmark", "vqe-energy_benchmark, param-sweep_benchmark")

Signed-off-by: Zachary Parks <1zp@ornl.gov>